### PR TITLE
Feature/f5names

### DIFF
--- a/Assets/Python/CvEventManager.py
+++ b/Assets/Python/CvEventManager.py
@@ -457,7 +457,8 @@ class CvEventManager:
             for iPlayer in range(gc.getMAX_PLAYERS()):
                 player = gc.getPlayer(iPlayer)
                 if (player.isAlive()):
-                    f.write("%s|||||||||||||||||||||||||||||||||||" % (player.getCivilizationDescription(1)))
+                    f.write("%s|||||||||||||||||||||||||||||||||||" %
+                        (player.getCivilizationDescription(1).encode('utf-8')))
             f.write("\n")
             for iPlayer in range(gc.getMAX_PLAYERS()):
                 player = gc.getPlayer(iPlayer)
@@ -536,11 +537,12 @@ class CvEventManager:
                     f.write("%d|" % (player.calculateUnitSupply()))
                     f.write("%d|" % (player.getCivicUpkeep([], False)))
                     f.write("%d|" % (player.getCivicUpkeepBonusTracking([], False)))
-                    f.write("%s|" % (gc.getCivicInfo(player.getCivics(0)).getDescription()))
-                    f.write("%s|" % (gc.getCivicInfo(player.getCivics(1)).getDescription()))
-                    f.write("%s|" % (gc.getCivicInfo(player.getCivics(2)).getDescription()))
-                    f.write("%s|" % (gc.getCivicInfo(player.getCivics(3)).getDescription()))
-                    f.write("%s|" % (gc.getCivicInfo(player.getCivics(4)).getDescription()))
+                    f.write("%s|" %
+                            (gc.getCivicInfo(player.getCivics(0)).getDescription().encode('utf-8')))
+                    f.write("%s|" % (gc.getCivicInfo(player.getCivics(1)).getDescription().encode('utf-8')))
+                    f.write("%s|" % (gc.getCivicInfo(player.getCivics(2)).getDescription().encode('utf-8')))
+                    f.write("%s|" % (gc.getCivicInfo(player.getCivics(3)).getDescription().encode('utf-8')))
+                    f.write("%s|" % (gc.getCivicInfo(player.getCivics(4)).getDescription().encode('utf-8')))
                     f.write("%s|" % (player.getWonderTracking()))
                     f.write("%s|" % (player.getGreatPersonTracking()))
                     f.write("%s|" % (player.getTechTracking()))

--- a/Assets/Python/Screens/CvBUGMilitaryAdvisor.py
+++ b/Assets/Python/Screens/CvBUGMilitaryAdvisor.py
@@ -583,8 +583,9 @@ class CvMilitaryAdvisor:
         if pWorstEnemy:
             self.iconGrid.addIcon(iRow, self.Col_WEnemy,
                                     gc.getLeaderHeadInfo(pWorstEnemy.getLeaderType()).getButton(), 45,  
-                                    *BugDll.widgetVersion(2, "WIDGET_LEADERHEAD_RELATIONS", iLeader, pWorstEnemy.getID(),
-                                                        WidgetTypes.WIDGET_LEADERHEAD, iLeader, pWorstEnemy.getID()))
+                                    *BugDll.widgetVersion(2, "WIDGET_LEADERHEAD_RELATIONS",
+                                        pWorstEnemy.getID(), iLeader,
+                                        WidgetTypes.WIDGET_LEADERHEAD, pWorstEnemy.getID(), iLeader))
         else:
             pass
             #self.iconGrid.addIcon(iRow, self.Col_WEnemy,

--- a/Assets/Python/Screens/CvBUGMilitaryAdvisor.py
+++ b/Assets/Python/Screens/CvBUGMilitaryAdvisor.py
@@ -150,7 +150,7 @@ class CvMilitaryAdvisor:
         self.iScreen = UNIT_LOCATION_SCREEN
 
         # icongrid constants
-        self.SHOW_LEADER_NAMES = False
+        self.SHOW_LEADER_NAMES = True
         self.SHOW_ROW_BORDERS = True
         self.MIN_TOP_BOTTOM_SPACE = 30
         self.MIN_LEFT_RIGHT_SPACE = 10
@@ -325,7 +325,6 @@ class CvMilitaryAdvisor:
 #               BugUtil.debug("Grid_ThreatIndex - Start %i" % (iLoopPlayer))
 
                 self.iconGrid.appendRow(pPlayer.getName(), "", 3)
-
                 # add leaderhead icon
                 self.iconGrid.addIcon(iRow, self.Col_Leader,
                                         gc.getLeaderHeadInfo(pPlayer.getLeaderType()).getButton(), 64, 
@@ -892,7 +891,12 @@ class CvMilitaryAdvisor:
             
             # Set scrollable area for leaders
             szPanel_ID = self.getNextWidgetName()
-            screen.addPanel(szPanel_ID, "", "", False, True, self.X_LEADERS, self.Y_LEADERS, self.W_LEADERS, self.H_LEADERS, PanelStyles.PANEL_STYLE_MAIN)
+            if self.SHOW_LEADER_NAMES:
+                screen.addPanel(szPanel_ID, "", "", False, True, self.X_LEADERS,
+                        self.Y_LEADERS - 22, self.W_LEADERS, self.H_LEADERS + 44, PanelStyles.PANEL_STYLE_MAIN)
+            else:
+                screen.addPanel(szPanel_ID, "", "", False, True, self.X_LEADERS,
+                        self.Y_LEADERS, self.W_LEADERS, self.H_LEADERS, PanelStyles.PANEL_STYLE_MAIN)
     
             listLeaders = []
             for iLoopPlayer in range(gc.getMAX_PLAYERS()):
@@ -924,6 +928,22 @@ class CvMilitaryAdvisor:
                 szLeaderButton = self.getLeaderButtonWidget(iLoopPlayer)              #self.getNextWidgetName()
                 screen.addCheckBoxGFC(szLeaderButton, szButton, ArtFileMgr.getInterfaceArtInfo("BUTTON_HILITE_SQUARE").getPath(), x, y, iButtonSize, iButtonSize, WidgetTypes.WIDGET_MINIMAP_HIGHLIGHT, 2, iLoopPlayer, ButtonStyles.BUTTON_STYLE_LABEL)
                 screen.setState(szLeaderButton, (iLoopPlayer in self.selectedLeaders))              
+
+                # Ramk - leader names
+                if self.SHOW_LEADER_NAMES:
+                    pname = gc.getPlayer(iLoopPlayer).getName()
+                    if iIndex % 2 == 0:
+                        screen.setText(szLeaderButton + "_name",
+                                "Background", pname, CvUtil.FONT_LEFT_JUSTIFY,
+                                x + 4, y+iButtonSize-2,
+                                self.Z_CONTROLS, FontTypes.TITLE_FONT,
+                                WidgetTypes.WIDGET_MINIMAP_HIGHLIGHT, 2, iLoopPlayer )
+                    else:
+                        screen.setText(szLeaderButton + "_name",
+                                "Background", pname, CvUtil.FONT_RIGHT_JUSTIFY,
+                                x + iButtonSize - 4, y-24,
+                                self.Z_CONTROLS, FontTypes.TITLE_FONT,
+                                WidgetTypes.WIDGET_MINIMAP_HIGHLIGHT, 2, iLoopPlayer )
         
         self.UL_refreshUnitSelection(bReload, bRedraw)
 

--- a/Assets/Python/Screens/IconGrid_BUG.py
+++ b/Assets/Python/Screens/IconGrid_BUG.py
@@ -822,6 +822,9 @@ class IconGrid_BUG:
     def hideRow(self, rowIndex):
         if (self.showRowBorder):
             self.screen.deleteWidget(self.rowName + str(rowIndex))
+
+        if (self.showRowHeader):
+            self.screen.deleteWidget(self.rowName + str(rowIndex) + "name")
         
         startIndex = 0
         for groupIndex in range(len(self.columnGroups)):


### PR DESCRIPTION
• First commit fixes encoding issue in CtHBalance.log generation. (Added a few .encode('utf-8') conversions for unicode objects).

• Second commit added leader name labels on the first tab of F5 screen.
For the other tabs it is already build in ( self.SHOW_LEADER_NAMES constant), but I fixed a issue in the underlying base class 
IconGrid_BUG.py

• Third commit swaps player Ids in the "worst enemy" section of the second tab. Now, the correct overlay of the given player is shown.