### PR TITLE
Fixes rounding error in whip evaluation

### DIFF
--- a/CvGameCoreDLL/CvCity.cpp
+++ b/CvGameCoreDLL/CvCity.cpp
@@ -4976,6 +4976,7 @@ int CvCity::getHurryCost(bool bExtra, BuildingTypes eBuilding, bool bIgnoreNew) 
 
 int CvCity::getHurryCost(bool bExtra, int iProductionLeft, int iHurryModifier, int iModifier) const
 {
+
 	int iProduction = (iProductionLeft * iHurryModifier + 99) / 100; // round up
 
 	if (bExtra)
@@ -4984,9 +4985,14 @@ int CvCity::getHurryCost(bool bExtra, int iProductionLeft, int iHurryModifier, i
 		if (iExtraProduction > 0)
 		{
 			int iAdjustedProd = iProduction * iProduction;
-			
+#if 0
 			// round up
 			iProduction = (iAdjustedProd + (iExtraProduction - 1)) / iExtraProduction;
+#else
+			// Ramk - Fix rounding bug for IMP settlers on 55H/100H.
+			int iProductionFactor10000 = getExtraProductionDifference(10000, iModifier); // modifation factor times 10000
+			iProduction = (iProduction * 10000 + (iProductionFactor10000-1)) / iProductionFactor10000; // round up
+#endif
 		}
 	}
 


### PR DESCRIPTION
The Civ4:BTS evaluation of the needed size of populations
contains a rounding error. This prevents whiping of settlers
with IMP trait and 45Hammers left.

(It also occours in more situations but this is the only relevant.)

This commit avoided rounding of intermediate values.